### PR TITLE
Fix build and update to RSpec 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,3 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
-# To use debugger
-# gem 'ruby-debug19', :require => 'ruby-debug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    redis_timeline (0.2.1)
-      activemodel (> 4.0)
-      activesupport (> 4.0)
+    redis-timeline (0.2.1)
+      activemodel
+      activesupport
       hashie
       multi_json
       rake
@@ -13,43 +13,47 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (4.1.0)
-      activesupport (= 4.1.0)
+    activemodel (4.1.6)
+      activesupport (= 4.1.6)
       builder (~> 3.1)
-    activesupport (4.1.0)
+    activesupport (4.1.6)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     builder (3.2.2)
-    diff-lcs (1.1.3)
-    hashie (2.1.0)
-    i18n (0.6.9)
+    diff-lcs (1.2.5)
+    hashie (3.3.1)
+    i18n (0.6.11)
     json (1.8.1)
-    minitest (5.3.2)
-    multi_json (1.9.2)
-    rake (10.2.2)
-    redis (3.0.7)
-    redis-namespace (1.4.1)
-      redis (~> 3.0.4)
-    rspec (2.10.0)
-      rspec-core (~> 2.10.0)
-      rspec-expectations (~> 2.10.0)
-      rspec-mocks (~> 2.10.0)
-    rspec-core (2.10.1)
-    rspec-expectations (2.10.0)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.10.1)
-    sqlite3 (1.3.5)
-    thread_safe (0.3.3)
-    tzinfo (1.1.0)
+    minitest (5.4.1)
+    multi_json (1.10.1)
+    rake (10.3.2)
+    redis (3.1.0)
+    redis-namespace (1.5.1)
+      redis (~> 3.0, >= 3.0.4)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.4)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.1)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.0)
+    sqlite3 (1.3.9)
+    thread_safe (0.3.4)
+    tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  redis_timeline!
+  redis-timeline!
   rspec
   sqlite3

--- a/spec/activity_spec.rb
+++ b/spec/activity_spec.rb
@@ -5,8 +5,8 @@ describe Timeline::Activity do
     let(:json) { { id: "1", verb: "new_post" } }
 
     it "returns a Hashie-fied object" do
-      Timeline::Activity.new(json).id.should == "1"
-      Timeline::Activity.new(json).verb.should == "new_post"
+      expect(Timeline::Activity.new(json).id).to eq("1")
+      expect(Timeline::Activity.new(json).verb).to eq("new_post")
     end
   end
 end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -11,7 +11,7 @@ describe Timeline::Actor do
     before { @user = User.new }
 
     it "defines a timeline association" do
-      @user.should respond_to :timeline
+      expect(@user).to respond_to :timeline
     end
 
     describe ".timeline" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), %w[.. lib redis_timeline]))
+require File.expand_path(File.join(File.dirname(__FILE__), %w[.. lib redis-timeline]))
 dir = File.dirname(File.expand_path(__FILE__))
 
 #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ end
 at_exit do
   next if $!
 
-  exit_code = RSpec::Runner.autorun
+  exit_code = RSpec::Core::Runner.autorun
 
   pid = `ps -A -o pid,command | grep [r]edis-test`.split(" ")[0]
   puts "Killing test redis server..."

--- a/spec/stdout
+++ b/spec/stdout
@@ -1,0 +1,6 @@
+[97466] 18 Sep 14:58:15.166 - DB 0: 5 keys (0 volatile) in 8 slots HT.
+[97466] 18 Sep 14:58:15.167 - 0 clients connected (0 slaves), 1006848 bytes in use
+[97466] 18 Sep 14:58:20.205 - DB 0: 5 keys (0 volatile) in 8 slots HT.
+[97466] 18 Sep 14:58:20.205 - 0 clients connected (0 slaves), 1006848 bytes in use
+[97466] 18 Sep 14:58:25.231 - DB 0: 5 keys (0 volatile) in 8 slots HT.
+[97466] 18 Sep 14:58:25.231 - 0 clients connected (0 slaves), 1006848 bytes in use

--- a/spec/timeline_spec.rb
+++ b/spec/timeline_spec.rb
@@ -1,12 +1,12 @@
 require File.join(File.dirname(__FILE__), %w[spec_helper])
 
 describe Timeline do
-  it("can set a redis instance") { Timeline.should respond_to(:redis=) }
-  it("has a namespace, timeline") { Timeline.redis.namespace.should == :timeline }
+  it("can set a redis instance") { expect(Timeline).to respond_to(:redis=) }
+  it("has a namespace, timeline") { expect(Timeline.redis.namespace).to eq(:timeline) }
 
   it "sets the namespace through a url-like string" do
     Timeline.redis = 'localhost:9736/namespace'
-    Timeline.redis.namespace.should == 'namespace'
+    expect(Timeline.redis.namespace).to eq('namespace')
   end
 end
 

--- a/spec/track_spec.rb
+++ b/spec/track_spec.rb
@@ -94,46 +94,46 @@ describe Timeline::Track do
 
   describe "included in an ActiveModel-compliant class" do
     it "tracks on create by default" do
-      post.should_receive(:track_new_post_after_create)
+      expect(post).to receive(:track_new_post_after_create)
       post.save
     end
 
     it "uses the creator as the actor by default" do
-      post.should_receive(:creator).and_return(mock("User", id: 1, to_param: "1", followers: []))
+      expect(post).to receive(:creator).and_return(double("User", id: 1, to_param: "1", followers: []))
       post.save
     end
 
     it "adds the activity to the global timeline set" do
       post.save
-      creator.timeline(:global).last.should be_kind_of(Timeline::Activity)
+      expect(creator.timeline(:global).last).to be_kind_of(Timeline::Activity)
     end
 
     it "adds the activity to the actor's timeline" do
       post.save
-      creator.timeline.last.should be_kind_of(Timeline::Activity)
+      expect(creator.timeline.last).to be_kind_of(Timeline::Activity)
     end
 
     it "cc's the actor's followers by default" do
       follower = User.new(id: 2)
-      User.any_instance.should_receive(:followers).and_return([follower])
+      expect_any_instance_of(User).to receive(:followers).and_return([follower])
       post.save
-      follower.timeline.last.verb.should == "new_post"
-      follower.timeline.last.actor.id.should == 1
+      expect(follower.timeline.last.verb).to eq("new_post")
+      expect(follower.timeline.last.actor.id).to eq(1)
     end
   end
 
   describe "with extra_fields" do
     it "stores the extra fields in the timeline" do
       comment.save
-      creator.timeline.first.object.should respond_to :post_id
+      expect(creator.timeline.first.object).to respond_to :post_id
     end
   end
 
   describe "tracking mentions" do
     it "adds to a user's mentions timeline" do
-      User.stub(:find_by_username).and_return(creator)
+      allow(User).to receive(:find_by_username).and_return(creator)
       Comment.new(creator_id: creator.id, body: "@first_user should see this").save
-      creator.timeline(:mentions).first.object.body.should == "@first_user should see this"
+      expect(creator.timeline(:mentions).first.object.body).to eq("@first_user should see this")
     end
   end
 end


### PR DESCRIPTION
1. Fixed a spec issue introduced by recent renaming
2. Bumped up RSpec version to 3.x
3. Updated Redis termination for 3.x
4. Addressed a number of deprecation warnings.

Build runs green.
